### PR TITLE
Add ssh key possibility to connection

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -168,7 +168,8 @@ export default class SyncFTP extends Plugin {
 					host: this.settings.url,
 					port: Number(this.settings.port),
 					username: this.settings.username,
-					password: this.settings.password
+					password: this.settings.password,
+					ssh_key_path: this.settings.ssh_key_path
 				});
 
 				if (this.settings.notify) new Notice(conn);

--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,7 @@ interface SyncFTPSettings {
 	vault_path: string;
 	notify: boolean;
 	load_sync: boolean;
+	ssh_key_path: string;
 }
 
 const DEFAULT_SETTINGS: SyncFTPSettings = {
@@ -23,7 +24,8 @@ const DEFAULT_SETTINGS: SyncFTPSettings = {
 	password: '',
 	vault_path: '/obsidian/',
 	notify: false,
-	load_sync: false
+	load_sync: false,
+	ssh_key_path: ''
 }
 
 export default class SyncFTP extends Plugin {
@@ -86,7 +88,8 @@ export default class SyncFTP extends Plugin {
 					host: this.settings.url,
 					port: Number(this.settings.port),
 					username: this.settings.username,
-					password: this.settings.password
+					password: this.settings.password,
+					ssh_key_path: this.settings.ssh_key_path
 				});
 
 				if (this.settings.notify) new Notice(conn);

--- a/main.ts
+++ b/main.ts
@@ -210,7 +210,7 @@ export default class SyncFTP extends Plugin {
 						let dst_path = (rem_file.path !== rem_path) ? `${rem_file.path.replace(rem_path,'')}/`: '';
 
 						if (rem_file.type !== 'd') {
-							sync = await this.client.downloadFile(`${rem_file.path}/${rem_file.name}`, `${loc_path}${dst_path}${rem_file.name}`);
+							sync = await this.client.downloadFile(`${rem_file.path}/${rem_file.name}`, `${loc_path}/${dst_path}${rem_file.name}`);
 						} else {
 							if (!loc_list.find(folder => folder.name === rem_file.name)) {
 								if (await this.client.fileExists(`${dst_path}${rem_file.name}/`) === false) {

--- a/src/credential.ts
+++ b/src/credential.ts
@@ -70,11 +70,21 @@ export default class CredentialTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Password')
-			.setDesc('FTP Password')
+			.setDesc('FTP Password or SSH Key Password if using an SSH Key')
 			.addText(text => text
 				.setValue(this.plugin.settings.password)
 				.onChange(async (value) => {
 					this.plugin.settings.password = value;
+					await this.plugin.saveSettings();
+				}));
+		
+		new Setting(containerEl)
+			.setName('SSH Key Path')
+			.setDesc('Path to SSH Key')
+			.addText(text => text
+				.setValue(this.plugin.settings.ssh_key_path)
+				.onChange(async (value) => {
+					this.plugin.settings.ssh_key_path = value;
 					await this.plugin.saveSettings();
 				}));
 


### PR DESCRIPTION
A simple implementation to get ssh keys to be able to be used with the plugin as I have only access to my SFTP server with ssh keys and decided to figure out how to modify the code to allow for this.

I have tested this and it does work as i also use a passphrase for my key file so i decided the easiest solution is to use the password field as the ssh key passphrase if the key file is specified

What might be needed is to check if the file actually exists but this works for my need and i cant spend much more time on it.